### PR TITLE
JEST-1550 build: upgrade to aws cli 2.17.50

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli:2.17.0
+FROM amazon/aws-cli:2.17.50
 
 COPY delete.sh /delete.sh
 


### PR DESCRIPTION
This pull request primarily focuses on upgrading aws cli to the [latest.](https://registry.hub.docker.com/layers/amazon/aws-cli/2.17.50/images/sha256-afa2788bc07c0cfcbdebc8acc079e91a8c53741bfd2c2b566ef99bce23802d4e?context=explore)