### PR TITLE
JEST-2305 - Upgrade to aws cli 2.34.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli:2.33.8
+FROM amazon/aws-cli:2.34.28
 
 COPY delete.sh /delete.sh
 


### PR DESCRIPTION
This pull request primarily focuses on upgrading aws cli to the [Latest](https://hub.docker.com/layers/amazon/aws-cli/2.34.28/images/sha256-1d482784b934bf423678d3f77ad421d4aeecde91fdf8f01b9ff3d5c0bde0dad6)